### PR TITLE
UI cleanups for the repo list page:

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -97,10 +97,22 @@ func getLocalRepos() (map[string]*repo.Repository, error) {
 		if err != nil {
 			return err
 		}
-		if info.IsDir() && info.Name() == ".git" {
-			gitRepo := repo.NewGitRepository(path, todoRegex, excludePaths)
-			repos[gitRepo.GetRepoId()] = &gitRepo
-			return filepath.SkipDir
+		if info.IsDir() {
+			dir, err := os.Open(path)
+			if err != nil {
+				return err
+			}
+			children, err := dir.Readdir(-1)
+			if err != nil {
+				return err
+			}
+			for _, child := range children {
+				if child.IsDir() && child.Name() == ".git" {
+					gitRepo := repo.NewGitRepository(path, todoRegex, excludePaths)
+					repos[gitRepo.GetRepoId()] = &gitRepo
+					return filepath.SkipDir
+				}
+			}
 		}
 		return nil
 	})

--- a/src/ui/list_repos.html
+++ b/src/ui/list_repos.html
@@ -40,19 +40,13 @@ limitations under the License.
     </div>
     <div class="container">
       <div class="row header-bar-lighter">
-        <div class="col-md-1">
+        <div class="col-md-12">
           <b>Path:</b>
         </div>
       </div>
-      <div class="row">
-        <div class="col-md-1">
-        </div>
-        <div class="col-md-11">
-          <div class="row alternate_row" ng-repeat="repo in repositories">
-            <div class="col-md-4">
-              <a href="list_branches.html#?repo={{repo.id}}">{{repo.path}}</a>
-            </div>
-          </div>
+      <div class="row alternate_row" ng-repeat="repo in repositories">
+        <div class="col-md-12">
+          <a href="list_branches.html#?repo={{repo.id}}">{{repo.path}}</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
1. Use the containing directory as the path instead of the ".git" subdirectory.
2. Because of #1, no longer include nested repos.
3. Fix the fomratting of the alternating repo lines, so that they fully extend to fill up the containing div, and that repo paths are not line wrapped when they don't need to be.