### PR TITLE
Small cleanups to the resource-constants helper script:

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ test:	resource-constants
 resource-constants: fmt
 	go build -o bin/resource-constants utils/resource-constants.go
 	if [ ! -e "src/resources" ]; then mkdir src/resources; fi
-	bin/resource-constants --base_dir $(shell pwd) > src/resources/constants.go
+	bin/resource-constants --base_dir $(shell pwd)/src/ui/ > src/resources/constants.go
 
 fmt:
 	gofmt -w `find ./ -name '*.go'`


### PR DESCRIPTION
1. Use filepath.Walk instead of duplicating that same functionality.
2. Use go/format to format the generated source code. This also gives a small amount of validation of the generated code.
3. Make the supported file extensions a flag, so that we can add new ones later on without having to rebuild the util.
4. Add godoc for the file.
5. Make the resource names be the relative file name rather than just the final part of the file name, which makes more sense for static files in nested directories.