### PR TITLE
Remove hr elements from throughout the UI.

### DIFF
--- a/src/ui/list_branches.html
+++ b/src/ui/list_branches.html
@@ -29,7 +29,6 @@ limitations under the License.
   <div class="container">
     <div class="row">
       <div class="col-md-12">
-        <hr>
         <h1 class="text-center csblue"><a href="/">TODO Tracker</a></h1>
       </div>
     </div>

--- a/src/ui/list_repos.html
+++ b/src/ui/list_repos.html
@@ -28,7 +28,6 @@ limitations under the License.
     <div class="container">
       <div class="row">
         <div class="col-md-12">
-          <hr>
           <h1 class="text-center csblue"><a href="/">TODO Tracker</a></h1>
         </div>
       </div>

--- a/src/ui/list_todos.html
+++ b/src/ui/list_todos.html
@@ -33,7 +33,6 @@ limitations under the License.
   <div class="container">
     <div class="row">
       <div class="col-md-12">
-        <hr>
         <h1 class="text-center csblue"><a href="/">TODO Tracker</a></h1>
       </div>
     </div>

--- a/src/ui/list_todos_paths.html
+++ b/src/ui/list_todos_paths.html
@@ -33,7 +33,6 @@ limitations under the License.
   <div class="container">
     <div class="row">
       <div class="col-md-12">
-        <hr>
         <h1 class="text-center csblue"><a href="/">TODO Tracker</a></h1>
       </div>
     </div>

--- a/src/ui/todo_details.html
+++ b/src/ui/todo_details.html
@@ -27,7 +27,6 @@ limitations under the License.
   <div class="container">
     <div class="row">
       <div class="col-md-12">
-        <hr>
         <h1 class="text-center csblue"><a href="/">TODO Tracker</a></h1>
       </div>
     </div>


### PR DESCRIPTION
Specifically, all of our pages started with an "<hr>" line before the title. Since those elements did not separate two logically-different pieces of the page, they didn't serve any purpose beyond formatting the following elements, which would be better done using css on those elements.