### PR TITLE
Fix failure to build with Go v1.16 or newer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/google/todo-tracks
+
+go 1.14


### PR DESCRIPTION
Fixes #18

From Go v1.16 there is no automatic changes to go.mod and go.sum, so `go.mod` needs to be added to the repo to make it work.

Details: https://go.dev/blog/go116-module-changes#no-automatic-changes-to-gomod-and-gosum